### PR TITLE
Hack for Intel Fortran compiler

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -1,0 +1,44 @@
+name: intel
+
+on: [push, pull_request]
+
+jobs:
+  intel-build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+
+    env:
+      FC: ifort
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+
+    - name: Add Intel repository
+      run: |
+        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo apt-get update
+
+    - name: Install Intel oneAPI compiler
+      run: |
+        sudo apt-get install intel-oneapi-compiler-fortran
+        source /opt/intel/oneapi/setvars.sh
+        printenv >> $GITHUB_ENV
+
+    - name: Install meson
+      run: pip3 install meson ninja
+
+    - name: meson build
+      run: |
+        meson setup _build
+        meson test -C _build

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -3,7 +3,7 @@ name: msys2
 on: [push, pull_request]
 
 jobs:
-  build:
+  msys2-build:
     runs-on: windows-latest
     defaults:
       run:

--- a/src/argparse-f.f90
+++ b/src/argparse-f.f90
@@ -37,6 +37,8 @@ module argparse
     subroutine sc_option_callback
     end subroutine sc_option_callback
   end interface
+  !> Hack for Intel Fortran
+  procedure(sc_option_callback), pointer :: dummy_print_help_wrapper => dummy_print_help
 
   type short_circuit_option
     character(len=short_name_len) :: short_name
@@ -169,7 +171,7 @@ contains
       do j = 1, argc
         tok = tokens(j)
         if (tok == this%sc_options(i)%short_name .or. tok == this%sc_options(i)%long_name) then
-          if (associated(this%sc_options(i)%callback, dummy_print_help)) then
+          if (associated(this%sc_options(i)%callback, dummy_print_help_wrapper)) then
             call this%print_help()
           else
             call this%sc_options(i)%callback()
@@ -215,7 +217,7 @@ contains
         idx = this%short_name_index(ichar(tok(i:i)))
         ! short circuit option
         if (idx <= this%sc_option_size .and. this%sc_options(idx)%short_name(2:2) == tok(i:i)) then
-          if (associated(this%sc_options(idx)%callback, dummy_print_help)) then
+          if (associated(this%sc_options(idx)%callback, dummy_print_help_wrapper)) then
             call this%print_help()
           else
             call this%sc_options(idx)%callback()


### PR DESCRIPTION
### Description

My experience tells me that Intel-compiler's `associated` function always has some bugs. Here is a hack to make argparse-f compatible with gfortran and ifort/ifx.

Close #3 .

- [x] Hack for Intel compilers;
- [x] Add CI for Intel compilers.