### PR TITLE
Minor modification, compliant with Fortran standard 2018

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,7 @@ project(
     license : 'MIT',
     default_options : [
         'buildtype=debugoptimized',
+        'fortran_std=f2018'
     ]
 )
 

--- a/src/argparse-f.f90
+++ b/src/argparse-f.f90
@@ -261,7 +261,7 @@ contains
     end do
     ! start parse position argument
     if (argc /= this%argument_size) then
-      print '(A,I3,A,I3)', "(parse error) position argument number missmatching, give ", argc, ", but need", this%argument_size
+      print '(A,I0,A,I0)', "(parse error) position argument number missmatching, give ", argc, ", but need ", this%argument_size
       error stop
     end if
     do i = 1, this%argument_size
@@ -356,11 +356,11 @@ contains
       end if
       print '(A,$)', trim(this%sc_options(i)%long_name)
       printed_length = printed_length + len_trim(this%sc_options(i)%long_name)
-      write (unit=help_fmt, fmt='("(",I3,"X,A,$)")') max_name_length - printed_length
+      write (unit=help_fmt, fmt='("(",I0,"X,A,$)")') max_name_length - printed_length
       print help_fmt, ''
       call split(this%sc_options(i)%help, "\n", help_split)
       print '(A)', trim(help_split(1))
-      write (unit=help_fmt, fmt='("(",I3,"X,A)")') max_name_length + 2
+      write (unit=help_fmt, fmt='("(",I0,"X,A)")') max_name_length + 2
       do j = 2, size(help_split, 1)
         print help_fmt, trim(help_split(j))
       end do
@@ -375,7 +375,7 @@ contains
       end if
       print '(A,$)', trim(this%options(i)%long_name)
       printed_length = printed_length + len_trim(this%options(i)%long_name)
-      write (unit=help_fmt, fmt='("(",I3,"X,A,$)")') max_name_length - printed_length
+      write (unit=help_fmt, fmt='("(",I0,"X,A,$)")') max_name_length - printed_length
       print help_fmt, ''
       call split(this%options(i)%help, "\n", help_split)
       if (this%options(i)%value_type == "logical") then
@@ -383,7 +383,7 @@ contains
       else
         print '("(",A,") ",A)', trim(this%options(i)%value_type), trim(help_split(1))
       end if
-      write (unit=help_fmt, fmt='("(",I3,"X,A)")') max_name_length + 2
+      write (unit=help_fmt, fmt='("(",I0,"X,A)")') max_name_length + 2
       do j = 2, size(help_split, 1)
         print help_fmt, trim(help_split(j))
       end do
@@ -400,12 +400,12 @@ contains
       do i = 1, this%named_argument_size
         print '(2X,A,$)', trim(this%named_arguments(i)%name)
         printed_length = len_trim(this%named_arguments(i)%name)
-        write (unit=help_fmt, fmt='("(",I3,"X,""("",A,"") "" ,$)")') max_name_length - printed_length
+        write (unit=help_fmt, fmt='("(",I0,"X,""("",A,"") "" ,$)")') max_name_length - printed_length
         ! print '(A)', help_fmt
         print help_fmt, trim(this%named_arguments(i)%value_type)
         call split(this%named_arguments(i)%help, "\n", help_split)
         print '(A)', trim(help_split(1))
-        write (unit=help_fmt, fmt='("(",I3,"X,A)")') max_name_length + 2
+        write (unit=help_fmt, fmt='("(",I0,"X,A)")') max_name_length + 2
         do j = 2, size(help_split, 1)
           print help_fmt, trim(help_split(j))
         end do
@@ -423,11 +423,11 @@ contains
       do i = 1, this%argument_size
         print '(2X,A,$)', trim(this%arguments(i)%name)
         printed_length = len_trim(this%arguments(i)%name)
-        write (unit=help_fmt, fmt='("(",I3,"X,""("",A,"") "" ,$)")') max_name_length - printed_length
+        write (unit=help_fmt, fmt='("(",I0,"X,""("",A,"") "" ,$)")') max_name_length - printed_length
         print help_fmt, trim(this%arguments(i)%value_type)
         call split(this%arguments(i)%help, "\n", help_split)
         print '(A)', trim(help_split(1))
-        write (unit=help_fmt, fmt='("(",I3,"X,A)")') max_name_length + 2
+        write (unit=help_fmt, fmt='("(",I0,"X,A)")') max_name_length + 2
         do j = 2, size(help_split, 1)
           print help_fmt, trim(help_split(j))
         end do

--- a/src/argparse-f.f90
+++ b/src/argparse-f.f90
@@ -304,12 +304,12 @@ contains
   subroutine argp_print_usage(this)
     class(argparser), intent(in) :: this
     integer :: i
-    print '("usage: ",A," [options]",$)', trim(this%program_name)
+    write (*, '("usage: ",A," [options]")', advance='no') trim(this%program_name)
     do i = 1, this%named_argument_size
-      print '(" [=",A,"]",$)', trim(this%named_arguments(i)%name)
+      write (*, '(" [=",A,"]")', advance='no') trim(this%named_arguments(i)%name)
     end do
     do i = 1, this%argument_size
-      print '(" [",A,"]",$)', trim(this%arguments(i)%name)
+      write (*, '(" [",A,"]")',  advance='no') trim(this%arguments(i)%name)
     end do
     print *, ""
   end subroutine argp_print_usage
@@ -348,16 +348,16 @@ contains
 
     ! print options
     do i = 1, this%sc_option_size
-      print '(A2,$)', "  "
+      write (*, '(A2)', advance='no') "  "
       printed_length = 0
       if (this%sc_options(i)%short_name /= "") then
-        print '(A,", ",$)', trim(this%sc_options(i)%short_name)
+        write (*, '(A,", ")', advance='no') trim(this%sc_options(i)%short_name)
         printed_length = 4
       end if
-      print '(A,$)', trim(this%sc_options(i)%long_name)
+      write (*, '(A)', advance='no') trim(this%sc_options(i)%long_name)
       printed_length = printed_length + len_trim(this%sc_options(i)%long_name)
-      write (unit=help_fmt, fmt='("(",I0,"X,A,$)")') max_name_length - printed_length
-      print help_fmt, ''
+      write (unit=help_fmt, fmt='("(",I0,"X,A)")') max_name_length - printed_length
+      write (*, help_fmt, advance='no') ''
       call split(this%sc_options(i)%help, "\n", help_split)
       print '(A)', trim(help_split(1))
       write (unit=help_fmt, fmt='("(",I0,"X,A)")') max_name_length + 2
@@ -367,16 +367,16 @@ contains
       deallocate (help_split)
     end do
     do i = 1, this%option_size
-      print '(A2,$)', "  "
+      write (*, '(A2)', advance='no') "  "
       printed_length = 0
       if (this%options(i)%short_name /= "") then
-        print '(A,", ",$)', trim(this%options(i)%short_name)
+        write (*, '(A,", ")', advance='no') trim(this%options(i)%short_name)
         printed_length = 4
       end if
-      print '(A,$)', trim(this%options(i)%long_name)
+      write (*, '(A)', advance='no') trim(this%options(i)%long_name)
       printed_length = printed_length + len_trim(this%options(i)%long_name)
-      write (unit=help_fmt, fmt='("(",I0,"X,A,$)")') max_name_length - printed_length
-      print help_fmt, ''
+      write (unit=help_fmt, fmt='("(",I0,"X,A)")') max_name_length - printed_length
+      write (*, help_fmt, advance='no') ''
       call split(this%options(i)%help, "\n", help_split)
       if (this%options(i)%value_type == "logical") then
         print '(A)', trim(help_split(1))
@@ -398,11 +398,11 @@ contains
       end do
       max_name_length = max(max_name_length, 25)
       do i = 1, this%named_argument_size
-        print '(2X,A,$)', trim(this%named_arguments(i)%name)
+        write (*, '(2X,A)', advance='no') trim(this%named_arguments(i)%name)
         printed_length = len_trim(this%named_arguments(i)%name)
-        write (unit=help_fmt, fmt='("(",I0,"X,""("",A,"") "" ,$)")') max_name_length - printed_length
+        write (unit=help_fmt, fmt='("(",I0,"X,""("",A,"") "")")') max_name_length - printed_length
         ! print '(A)', help_fmt
-        print help_fmt, trim(this%named_arguments(i)%value_type)
+        write (*, help_fmt, advance='no') trim(this%named_arguments(i)%value_type)
         call split(this%named_arguments(i)%help, "\n", help_split)
         print '(A)', trim(help_split(1))
         write (unit=help_fmt, fmt='("(",I0,"X,A)")') max_name_length + 2
@@ -421,10 +421,10 @@ contains
       end do
       max_name_length = max(max_name_length, 25)
       do i = 1, this%argument_size
-        print '(2X,A,$)', trim(this%arguments(i)%name)
+        write (*, '(2X,A)', advance='no') trim(this%arguments(i)%name)
         printed_length = len_trim(this%arguments(i)%name)
-        write (unit=help_fmt, fmt='("(",I0,"X,""("",A,"") "" ,$)")') max_name_length - printed_length
-        print help_fmt, trim(this%arguments(i)%value_type)
+        write (unit=help_fmt, fmt='("(",I0,"X,""("",A,"") "")")') max_name_length - printed_length
+        write (*, help_fmt, advance='no') trim(this%arguments(i)%value_type)
         call split(this%arguments(i)%help, "\n", help_split)
         print '(A)', trim(help_split(1))
         write (unit=help_fmt, fmt='("(",I0,"X,A)")') max_name_length + 2


### PR DESCRIPTION
### Description

`$` is not Fortran standard syntax, and the standard `advance='no'` seems more appropriate for the long run of this project.

Also, `i3` may run out of length, so `i0` would be better.