### PR TITLE
Show default values in Help

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -24,6 +24,8 @@ jobs:
       - name: fpm test
         run: |
           fpm test
+          fpm test -- -?
+          fpm test -- -v
 
       - name: meson test
         run: |

--- a/src/argparse-f.f90
+++ b/src/argparse-f.f90
@@ -326,7 +326,7 @@ contains
     do i = 1, size(help_split)
       print '(A)', trim(help_split(i))
     end do
-    print '(/,A)', "Options:"
+    print '(/,A)', "options:"
 
     ! calculate the longest option name
     max_name_length = 0
@@ -391,7 +391,7 @@ contains
     end do
 
     if (this%named_argument_size > 0) then
-      print '(/,A)', "Named arguments:"
+      print '(/,A)', "named arguments:"
       max_name_length = 0
       do i = 1, this%named_argument_size
         max_name_length = max(max_name_length, len_trim(this%named_arguments(i)%name))

--- a/src/argparse-f.f90
+++ b/src/argparse-f.f90
@@ -381,7 +381,7 @@ contains
       if (this%options(i)%value_type == "logical") then
         print '(A)', trim(help_split(1))
       else
-        print '("(",A,") ",A)', trim(this%options(i)%value_type), trim(help_split(1))
+        print '("(",A," [=",A,"]) ",A)', trim(this%options(i)%value_type), trim(this%options(i)%value), trim(help_split(1))
       end if
       write (unit=help_fmt, fmt='("(",I0,"X,A)")') max_name_length + 2
       do j = 2, size(help_split, 1)


### PR DESCRIPTION
### Description
It is useful to display default values in help, which `cmdline` and `argparse` do. Also, lower case the first letter of the title, in keeping with `cmdline` and `argparse`.

```sh
usage:
options:
named arguments:
```

PS. GitHub's diff display is showing an error, and I'll point out the line of code I changed.