### PR TITLE
Fix CI, use ifx instead of ifort

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -23,17 +23,19 @@ jobs:
 
     - name: Add Intel repository
       run: |
-        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-        rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+        rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
         echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
         sudo apt-get update
 
-    - name: Install Intel oneAPI compiler
+    - name: Install Intel oneAPI compiler (ifx)
       run: |
-        sudo apt-get install intel-oneapi-compiler-fortran
+        sudo apt-get install intel-oneapi-compiler-fortran-2024.1
         source /opt/intel/oneapi/setvars.sh
         printenv >> $GITHUB_ENV
+        export FC=ifx
+        echo FC=$FC>>$GITHUB_ENV
 
     - name: Install meson
       run: pip3 install meson ninja
@@ -42,3 +44,7 @@ jobs:
       run: |
         meson setup _build
         meson test -C _build
+
+    - name: catch build fail
+      run: cat _build/meson-logs/meson-log.txt
+      if: ${{ failure() }}

--- a/fpm.toml
+++ b/fpm.toml
@@ -10,6 +10,3 @@ auto-tests = true
 auto-examples = true
 [install]
 library = false
-[dev-dependencies]
-test-drive.git = "https://github.com/fortran-lang/test-drive"
-test-drive.tag = "v0.4.0"

--- a/src/argparse-f.f90
+++ b/src/argparse-f.f90
@@ -433,7 +433,7 @@ contains
     end if
 
     if (this%argument_size > 0) then
-      print '(/,A)', "Position rguments:"
+      print '(/,A)', "Position arguments:"
       max_name_length = 0
       do i = 1, this%argument_size
         max_name_length = max(max_name_length, len_trim(this%arguments(i)%name))


### PR DESCRIPTION
## Description

Currently, ifort has been deprecated by Intel and error reports have been thrown out. This PR uses ifx instead of ifort to test argparse-f.
And a typo has been fixed, and the unused test-drive has been removed. 